### PR TITLE
Resolved audio context issue; can play unlimited number of songs

### DIFF
--- a/app/public/js/audioSource.js
+++ b/app/public/js/audioSource.js
@@ -43,6 +43,11 @@ window.onload = function () {
        // app.audio.play();
        var play = true;
        document.body.appendChild(audio);
+
+       if (typeof context !== 'undefined'){
+        console.log("Out with the old.. in with the new!");
+        context.close();
+        }
        // app.ctx = new (window.AudioContext || window.webkitAudioContext)(); // creates audioNode
        // source = app.ctx.createMediaElementSource(app.audio); // creates audio source
        // analyser = app.ctx.createAnalyser(); // creates analyserNode


### PR DESCRIPTION
I added some logic to audioSource which appears to solve the audioContext limit issue.  I believe we can drag/drop any number of songs.  Upon review and if successful, we can close out issue #75.  Thanks!